### PR TITLE
Fix for the very common infinite loop issue, when forgetting to call getIterator

### DIFF
--- a/src/lazylualinq.lua
+++ b/src/lazylualinq.lua
@@ -161,11 +161,11 @@ end
 function linq.factory(fac)
 	return setmetatable({}, { 
 		__call = function(self, ...)
-            local numArgs = select('#', ...)
-            if numArgs > 0 then
-                error("Invalid use of lazylualinq sequence.  Did you forget to call it (or getIterator) before using it inside a for loop?", 2)
-            end
-            return fac(self)
+			local numArgs = select('#', ...)
+			if numArgs > 0 then
+				error("Invalid use of lazylualinq sequence.  Did you forget to call it (or getIterator) before using it inside a for loop?", 2)
+			end
+			return fac(self)
 		end,
 		__index = linq,
 		__len = function(self) 

--- a/src/lazylualinq.lua
+++ b/src/lazylualinq.lua
@@ -160,7 +160,13 @@ end
 -- as other functions that return a sequence.
 function linq.factory(fac)
 	return setmetatable({}, { 
-		__call = fac, 
+		__call = function(self, ...)
+            local numArgs = select('#', ...)
+            if numArgs > 0 then
+                error("Invalid use of lazylualinq sequence.  Did you forget to call it (or getIterator) before using it inside a for loop?", 2)
+            end
+            return fac(self)
+		end,
 		__index = linq,
 		__len = function(self) 
 			return self:count()

--- a/test/intermediate/for_loop.lua
+++ b/test/intermediate/for_loop.lua
@@ -1,0 +1,33 @@
+
+describe("for loop usage", function()
+	local linq = require("lazylualinq")
+
+	it("throws error when getIterator is not called", function()
+		local seq = linq { 1, 2, 3 }
+
+        assert.has_error(function() 
+            for _x in seq do
+            end
+        end)
+
+        local items = {}
+        for x in seq() do
+            table.insert(items, x)
+        end
+
+		assert.is_same(#items, 3)
+		assert.is_same(items[1], 1)
+		assert.is_same(items[2], 2)
+		assert.is_same(items[3], 3)
+
+        items = {}
+        for x in seq:getIterator() do
+            table.insert(items, x)
+        end
+
+		assert.is_same(#items, 3)
+		assert.is_same(items[1], 1)
+		assert.is_same(items[2], 2)
+		assert.is_same(items[3], 3)
+	end)
+end)


### PR DESCRIPTION

I find that when using this library, it is very common to accidentally create infinite loops like this:

    for value in lazylualinq.range(1, 10)
       :filter("v % 2 == 0") do
       print(value)
    end

Instead of properly doing this:

    for value in lazylualinq.range(1, 10)
       :filter("v % 2 == 0")() do
       print(value)
    end

I think this is because when the for loop is given a table that has __call metamethod, it assumes it is a normal iterator function, and repeatedly calls it, causing a new iterator function to be created each iteration of the loop.  Otherwise it would just produce an error instead of an infinite loop.

For some lua environments an infinite loop is much worse than just triggering an error.  We can detect this mistake though, since when lua calls the given iterator function it passes in two parameter values.  So we can differentiate between when the lua for-method calls it and when the user calls it themselves.

I am using select() because the parameter values are passed as nil values, so #{...} would return 0